### PR TITLE
feat: parallel page deletion feature

### DIFF
--- a/opt/notion_manager.py
+++ b/opt/notion_manager.py
@@ -1,3 +1,5 @@
+from concurrent.futures import ThreadPoolExecutor
+
 from notion_client import Client
 
 
@@ -25,7 +27,11 @@ class NotionManager:
                 notion_tags.append({"name": tag})
         return notion_tags
 
+    def delete_page(self,page_id):
+        self.notion.pages.update(page_id=page_id, archived=True)
+
     def delete_all_pages(self):
         pages = self.notion.databases.query(database_id=self.database_id)
-        for page in pages['results']:
-            self.notion.pages.update(page_id=page['id'], archived=True)
+        with ThreadPoolExecutor() as executor:
+            # ページを並列で削除する
+            [executor.submit(self.delete_page, page['id']) for page in pages['results']]


### PR DESCRIPTION
# feat
* Refactor the delete_all_pages function to use ThreadPoolExecutor and delete pages in parallel for faster processing.

up : Processing time before optimization → 6s
down: processing time after optimization → 2s

![image](https://user-images.githubusercontent.com/41669061/235468184-a4ee390a-7db8-4d50-a9bf-78fc178e4cd5.png)
